### PR TITLE
fix :"팀 일정 스터디 선택 문제 해결"

### DIFF
--- a/src/components/teamschedules/TeamAddSchedule.js
+++ b/src/components/teamschedules/TeamAddSchedule.js
@@ -4,7 +4,7 @@ import "react-datepicker/dist/react-datepicker.css";
 import ScheduleAdd from "../../css/schedule_css/ScheduleAdd.css";
 import { CirclePicker } from "react-color";
 
-const TeamAddSchedule = ({studies,studyTitles, selectedDate, onInsert, onClose }) => {
+const TeamAddSchedule = ({studyId,studies,studyTitles, selectedDate, onInsert, onClose }) => {
   const localDate = new Date(selectedDate);
   const localDateString = localDate.toLocaleDateString();
   const [startDate, setStartDate] = useState(new Date(selectedDate));
@@ -13,26 +13,13 @@ const TeamAddSchedule = ({studies,studyTitles, selectedDate, onInsert, onClose }
   const [content, setContent] = useState("");
   const [color, setColor] = useState("");
   const [InsertToDoTitle, setInsertToDoTitle] = useState("")
-  const [InsertStudyId, setInsertStudyId] = useState(studies[0].study.id) // 초기값 : 첫 번째 스터디 (기본 선택값)
-  const [InsertStudy, setInsertStudy] = useState([]); //선택한 스터디 객체
-  const studyIdAsNumber = parseFloat(InsertStudyId);
-
+  const studyIdAsNumber = parseFloat(studyId);
   const onChangeTitle = useCallback((e) => {
     setTitle(e.target.value);
   }, []);
   const onChangeContent = useCallback((e) => {
     setContent(e.target.value);
   }, []);
-  const selectScehduleStudy = (e) => {
-    setInsertToDoTitle(e.target.value)
-    const selectedStudy = studies.find((study) => study.study.title === e.target.value);
-    const selectedId = selectedStudy.study.id;
-    setInsertStudyId(selectedId);
-    setInsertStudy(selectedStudy.study);
-    console.log(e.target.value);
-    console.log("선택한 스터디 아이디", selectedId);
-    console.log("선택한 스터디", selectedStudy.study);
-  }
 
   const onChangeColor = useCallback((color) => {
     setColor(color.hex);
@@ -60,12 +47,7 @@ const TeamAddSchedule = ({studies,studyTitles, selectedDate, onInsert, onClose }
         <form className="Scheduleedit_insert">
           <h2>{localDateString}</h2>
           <div className="selectstudy">
-            <p>스터디 선택:</p>
-            <select onChange={selectScehduleStudy} disabled>
-              {studyTitles.map((item, index) => (
-                  <option key={index} value={item}>{item}</option>
-              ))}
-            </select>
+
           </div>
           <div className="selectDay">
             <div className="selectstartDay">

--- a/src/components/teamschedules/TeamScheduleCalender.js
+++ b/src/components/teamschedules/TeamScheduleCalender.js
@@ -6,10 +6,11 @@ import RenderDays from "../calender/RenderDays";
 import ScheduleCalender_CSS from "../../css/schedule_css/ScheduleCalender.css";
 import TeamRenderScheduleCells from "./TeamRenderScheduleCells";
 
-const TeamScheduleCalender = ({studies, studyTitles,onDateClick ,meetings, schedules,onUpdate,onRemove}) => {
+const TeamScheduleCalender = ({studyId,studies, studyTitles,onDateClick ,meetings, schedules,onUpdate,onRemove}) => {
     const [currentMonth, setCurrentMonth] = useState(new Date());
     const [selectedDate, setSelectedDate] = useState(new Date());
 
+    console.log("studies:", studies);
     const prevMonth = () => {
         setCurrentMonth(subMonths(currentMonth, 1));
     };

--- a/src/pages/TeamSchedule/TeamSchedule.js
+++ b/src/pages/TeamSchedule/TeamSchedule.js
@@ -143,9 +143,10 @@ const TeamSchedule = () => {
             <Category/>
             <div className="main_schedule_container">
                 <p id={"entry-path"}> 스터디 참여내역 > 팀블로그 > 팀 스터디 일정</p>
-                <Backarrow subname={"스터디 모임 일정"}/>
+                <Backarrow subname={"팀 스터디 모임 일정"}/>
                 <div className="sub_container" id="todo_sub">
                     <TeamScheduleCalender
+                        studyId = {studyId}
                         studies={studies}
                         studyTitles={studyTitles}
                         onDateClick={handleToggle}
@@ -156,6 +157,7 @@ const TeamSchedule = () => {
                     />
                 </div>
                 {addToggle && (<TeamAddSchedule
+                    studyId = {studyId}
                     studies={studies}
                     studyTitles={studyTitles}
                     selectedDate={selectedDate}


### PR DESCRIPTION
- [x] 팀블로그 일정 추가 컴포넌트에 스터디 선택버튼을 삭제하고 스터디 id를 매개변수로 받아와서 일정 추가함
![image](https://github.com/Hanium2023-WeB/starD-frontend/assets/80142915/d8602dae-1cb1-4922-9789-0b050ea194ab)

- [x] 추가한 후에 마이페이지에서 일정을 보면 모든 스터디의 일정을 볼 수 있음
결과
![image](https://github.com/Hanium2023-WeB/starD-frontend/assets/80142915/4b029b84-11e4-485f-a94b-d32d8c3e8a17)
 
결과
- [x] 팀 스터디 일정을 클릭하면 해당 스터디의 일정만 보이도록 구현

![image](https://github.com/Hanium2023-WeB/starD-frontend/assets/80142915/02e4db33-81af-4f88-97a2-cfffd588aa67)
