### PR TITLE
fix: 비밀번호 재설정 이메일 전달 시 이메일 유효성 추가 /  alert 창 대신 toast 사용

### DIFF
--- a/src/components/study/StudyListItem.js
+++ b/src/components/study/StudyListItem.js
@@ -33,7 +33,7 @@ function checkProgressStatus(recruitStatus, proressStatus){
 }
 
 const StudyListItem = ({studies, toggleScrap, index, isParticipateStudy, goNextTeamBlog, goEvaluationPage}) => {
-    console.log(studies);
+    // console.log(studies);
     const imgUrl = studies.imgUrl ? studies.imgUrl : default_profile_img;
     const daysDifference = calculateDateDifference(studies.activityStart, studies.activityDeadline);
     const recruitStatus = isParticipateStudy ? checkProgressStatus(studies.progressType) : checkRecruitStatus(studies.recruitmentType, studies.progressType);
@@ -91,6 +91,7 @@ const StudyListItem = ({studies, toggleScrap, index, isParticipateStudy, goNextT
                         ) : null}
                     </div>
                 )}
+
             </div>
         </div>
     )

--- a/src/pages/studypage/Study.js
+++ b/src/pages/studypage/Study.js
@@ -11,6 +11,7 @@ import StudyListItem from "../../components/study/StudyListItem";
 import Paging from "../../components/repeat_etc/Paging";
 import Loading from "../../components/repeat_etc/Loading";
 import {toggleScrapStatus} from "../../util/scrapHandler";
+import toast from "react-hot-toast";
 
 const Study = () => {
   const navigate = useNavigate();
@@ -104,8 +105,8 @@ const Study = () => {
       e.preventDefault();
       navigate(`/study/insert`);
     } else {
-      alert("로그인 해주세요");
-      navigate("/login");
+      toast.error("로그인 후 이용 가능합니다.");
+      // navigate("/login");
     }
   };
 

--- a/src/pages/userpage/FindPW.js
+++ b/src/pages/userpage/FindPW.js
@@ -2,6 +2,7 @@ import Header from "../../components/repeat_etc/Header";
 import React, {useRef, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import axios from "axios";
+import toast from "react-hot-toast";
 
 const FindPW = () => {
 
@@ -14,7 +15,6 @@ const FindPW = () => {
   const navigate = useNavigate();
 
   const handleEditChange = (e) => {
-    console.log(e.target.value.toString());
     setState({
       ...state,
       [e.target.name]: e.target.value.toString(),
@@ -22,11 +22,16 @@ const FindPW = () => {
   };
 
   const vaildateCertificate = () => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(state.email)) {
+      toast.error("유효하지 않은 이메일 형식입니다.");
+      inputEmail.current.focus();
+      return;
+    }
 
     const emailDto = {
       email: state.email
     };
-    console.log(emailDto.email);
 
     axios.post("/api/members/auth/find-password", emailDto)
     .then((res) => {
@@ -64,6 +69,7 @@ const FindPW = () => {
                       ref={inputEmail}
                       id="phonecontent"
                       name={"email"}
+                      type="email"
                       value={state.email}
                       onChange={handleEditChange}
                       placeholder={"이메일을 입력해주세요."}

--- a/src/util/scrapHandler.js
+++ b/src/util/scrapHandler.js
@@ -1,9 +1,9 @@
 import axios from "axios";
+import toast from "react-hot-toast";
 
 export const toggleScrapStatus = async (study, accessToken, isLoggedInUserId, onSuccess, onError) => {
     if (!(accessToken && isLoggedInUserId)) {
-        alert("로그인 해주세요");
-        return;
+        return toast.error("로그인 후 이용 가능합니다.");
     }
 
     const targetId = study.studyPostId ? study.studyPostId : study.studyId;


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #142 

## 📝 작업 내용
-   비밀번호 재설정 이메일 전달 시 이메일 유효성 추가
- alert 창 대신 toast 사용
## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
