### PR TITLE
fix: 투두 담당자 여부 확인하기 위해 닉네임 대신 이메일로 검증

### DIFF
--- a/src/components/teamtodo/TeamToDoListItem.js
+++ b/src/components/teamtodo/TeamToDoListItem.js
@@ -45,7 +45,7 @@ const TeamToDoListItem = ({
     //
     //
     const loggedInUserId = localStorage.getItem('isLoggedInUserId');
-    const currentUserTodoIndex = todos.findIndex(todo => todo.nickname === loggedInUserId);
+    const currentUserTodoIndex = todos.findIndex(todo => todo.email === loggedInUserId);
     //
     // 만약 현재 로그인한 사용자의 할 일이 존재한다면 해당 할 일의 상태를 전달합니다.
     // const currentUserTodoStatus = currentUserTodoIndex !== -1 ? todos[currentUserTodoIndex].toDoStatus : false;
@@ -104,8 +104,8 @@ const TeamToDoListItem = ({
                                 className={cn('checkbox', { checked: todos[index].toDoStatus })}
                                 onClick={() => {
                                     // 현재 사용자가 담당자인 경우에만 체크를 토글
-                                    if (todo.assignees[index].memberId === loggedInUserId) {
-                                        onToggle(assignee.assigneeId, todo.id, currentUserTodoIndex, todos[index].toDoStatus);
+                                    if (todo.assignees[index].email === loggedInUserId) {
+                                        onToggle(todo.assignees[index].assigneeId, todo.toDoId, currentUserTodoIndex, todos[index].toDoStatus);
                                     } else {
                                         // 체크가 불가능함을 알리는 메시지를 표시할 수 있습니다.
                                         alert("본인만 체크할 수 있습니다.");


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #161 

## 📝 작업 내용
-   투두 담당자 여부 확인하기 위해 닉네임 대신 이메일로 검증
## 📚 Reference


## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요   

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 변경 내용에 대한 테스트를 진행했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
